### PR TITLE
fix: bump kms-all-inclusive and IBM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v1.0.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0, < 2.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
 
 ### Modules

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.56.1"
+      version = "1.62.0"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -8,14 +8,14 @@ This examples handles the provisioning of a new Secrets Manager instance.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v1.0.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.62.0 |
 
 ### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_event_notification"></a> [event\_notification](#module\_event\_notification) | terraform-ibm-modules/event-notifications/ibm | 1.2.2 |
-| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | terraform-ibm-modules/key-protect-all-inclusive/ibm | 4.8.4 |
+| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | terraform-ibm-modules/kms-all-inclusive/ibm | 4.8.5 |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform-ibm-modules/resource-group/ibm | 1.1.5 |
 | <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | ../.. | n/a |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,8 +7,8 @@ module "resource_group" {
 }
 
 module "key_protect" {
-  source                    = "terraform-ibm-modules/key-protect-all-inclusive/ibm"
-  version                   = "4.8.4"
+  source                    = "terraform-ibm-modules/kms-all-inclusive/ibm"
+  version                   = "4.8.5"
   key_protect_instance_name = "${var.prefix}-key-protect"
   resource_group_id         = module.resource_group.resource_group_id
   region                    = var.region

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.62.0"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.61.0, <2.0.0"
+      version = ">=1.62.0, <2.0.0"
     }
   }
 }

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -31,7 +31,7 @@ module "secrets_manager" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, <1.7.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.61.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.62.0, <2.0.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -8,7 +8,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Use "greater than or equal to" range in modules
-      version = ">=1.61.0, <2.0.0"
+      version = ">=1.62.0, <2.0.0"
     }
   }
 }

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -22,7 +22,7 @@ module "kms" {
   }
   count                       = var.existing_sm_kms_key_crn != null ? 0 : 1 # no need to create any KMS resources if passing an existing key, or bucket
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                     = "4.8.3"
+  version                     = "4.8.5"
   create_key_protect_instance = false
   region                      = var.kms_region
   existing_kms_instance_guid  = var.existing_kms_guid

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.62.0, < 2.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### Description

Bump IBM Provider to 1.62.0 (to support pending CBR upgrade in main module)
Bump key-protect-all-inclusive to kms-all-inclusive to be consistent across module (examples only)
Bump kms-all-inclusive to latest 3.8.5 version (solutions/standard DA)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Bump to IBM Provider 1.62.0.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
