### PR TITLE
fix: broken topic event notifications

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -34,7 +34,7 @@ module "kms" {
   }
   count                       = var.existing_secrets_manager_crn != null || var.existing_secrets_manager_kms_key_crn != null ? 0 : 1 # no need to create any KMS resources if passing an existing key, or bucket
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                     = "4.13.4"
+  version                     = "4.13.2"
   create_key_protect_instance = false
   region                      = local.kms_region
   existing_kms_instance_guid  = local.existing_kms_guid
@@ -163,8 +163,15 @@ data "ibm_en_destinations" "en_destinations" {
   instance_guid = local.existing_en_guid
 }
 
+resource "time_sleep" "wait_for_secrets_manager" {
+  depends_on = [module.secrets_manager]
+
+  create_duration = "30s"
+}
+
 resource "ibm_en_topic" "en_topic" {
   count         = var.existing_event_notification_instance_crn != null ? 1 : 0
+  depends_on    = [time_sleep.wait_for_secrets_manager]
   instance_guid = local.existing_en_guid
   name          = "Secrets Manager Topic"
   description   = "Topic for Secrets Manager events routing"

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -34,7 +34,7 @@ module "kms" {
   }
   count                       = var.existing_secrets_manager_crn != null || var.existing_secrets_manager_kms_key_crn != null ? 0 : 1 # no need to create any KMS resources if passing an existing key, or bucket
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                     = "4.13.2"
+  version                     = "4.13.4"
   create_key_protect_instance = false
   region                      = local.kms_region
   existing_kms_instance_guid  = local.existing_kms_guid

--- a/solutions/standard/version.tf
+++ b/solutions/standard/version.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = "1.66.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1, < 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
### Description

Fix issue with topics failing on initial apply and add sleep which depends on secrets manager module.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fix issue with topics failing on initial apply and add sleep which depends on secrets manager module.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
