### PR TITLE
fix: enable event notifications in secrets manager DA

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -6,6 +6,8 @@ locals {
   validate_resource_group = (var.existing_secrets_manager_crn == null && var.resource_group_name == null) ? tobool("Resource group name can not be null if existing secrets manager CRN is not set.") : true
   # tflint-ignore: terraform_unused_declarations
   validate_event_notifications = (var.existing_event_notification_instance_crn == null && var.enable_event_notification) ? tobool("To enable event notifications, an existing event notifications CRN must be set.") : true
+  # tflint-ignore: terraform_unused_declarations
+  validate_event_notifications_disabled = (var.existing_event_notification_instance_crn != null && !var.enable_event_notification) ? tobool("When an existing event notifications CRN is set, enable_event_notification should be true.") : true
 }
 
 module "resource_group" {

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -90,7 +90,10 @@ variable "public_engine_enabled" {
   default     = false
 }
 
+########################################################################################################################
 # Public cert engine config
+########################################################################################################################
+
 variable "public_engine_name" {
   type        = string
   description = "The name of the IAM engine used to configure a Secrets Manager public certificate engine for an existing instance."
@@ -122,7 +125,10 @@ variable "acme_letsencrypt_private_key" {
   default     = null
 }
 
+########################################################################################################################
 # Private cert engine config
+########################################################################################################################
+
 variable "private_engine_enabled" {
   type        = bool
   description = "Set this to true to configure a Secrets Manager private certificate engine for an existing instance. If set to false, no private certificate engine will be configured for your instance."
@@ -164,6 +170,10 @@ variable "certificate_template_name" {
   description = "The name of the certificate template."
   default     = "default-cert-template"
 }
+
+########################################################################################################################
+# IAM engine config
+########################################################################################################################
 
 variable "iam_engine_enabled" {
   type        = bool
@@ -235,6 +245,12 @@ variable "ibmcloud_kms_api_key" {
 ########################################################################################################################
 # Event Notifications
 ########################################################################################################################
+
+variable "enable_event_notification" {
+  type        = bool
+  default     = false
+  description = "Set this to true to enable lifecycle notifications for your Secrets Manager instance by connecting an Event Notifications service. When setting this to true, a value must be passed for `existing_en_instance_crn` variable."
+}
 
 variable "existing_event_notification_instance_crn" {
   type        = string

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -195,6 +195,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"region":                                   region,
 				"resource_group_name":                      terraform.Output(t, existingTerraformOptions, "resource_group_name"),
 				"use_existing_resource_group":              true,
+				"enable_event_notifications":               true,
 				"existing_event_notification_instance_crn": terraform.Output(t, existingTerraformOptions, "event_notification_instance_crn"),
 				"existing_secrets_manager_crn":             terraform.Output(t, existingTerraformOptions, "secrets_manager_instance_crn"),
 				"iam_engine_enabled":                       true,

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -222,6 +222,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"region":                                   region,
 				"resource_group_name":                      terraform.Output(t, existingTerraformOptions, "resource_group_name"),
 				"use_existing_resource_group":              true,
+				"enable_event_notification":                true,
 				"existing_event_notification_instance_crn": terraform.Output(t, existingTerraformOptions, "event_notification_instance_crn"),
 				"existing_secrets_manager_kms_key_crn":     terraform.Output(t, existingTerraformOptions, "secrets_manager_kms_key_crn"),
 				"existing_kms_instance_crn":                terraform.Output(t, existingTerraformOptions, "secrets_manager_kms_instance_crn"),

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -195,7 +195,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"region":                                   region,
 				"resource_group_name":                      terraform.Output(t, existingTerraformOptions, "resource_group_name"),
 				"use_existing_resource_group":              true,
-				"enable_event_notifications":               true,
+				"enable_event_notification":                true,
 				"existing_event_notification_instance_crn": terraform.Output(t, existingTerraformOptions, "event_notification_instance_crn"),
 				"existing_secrets_manager_crn":             terraform.Output(t, existingTerraformOptions, "secrets_manager_instance_crn"),
 				"iam_engine_enabled":                       true,


### PR DESCRIPTION
### Description

A flag is required to enable/disable event notifications on the DA (#176)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

For the deployable architecture when passing an `existing_event_notification_instance_crn` it is necessary to set `enable_event_notification` to true.

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
