### PR TITLE
fix: for DA reduce validation on event notifications

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -6,8 +6,6 @@ locals {
   validate_resource_group = (var.existing_secrets_manager_crn == null && var.resource_group_name == null) ? tobool("Resource group name can not be null if existing secrets manager CRN is not set.") : true
   # tflint-ignore: terraform_unused_declarations
   validate_event_notifications = (var.existing_event_notification_instance_crn == null && var.enable_event_notification) ? tobool("To enable event notifications, an existing event notifications CRN must be set.") : true
-  # tflint-ignore: terraform_unused_declarations
-  validate_event_notifications_disabled = (var.existing_event_notification_instance_crn != null && !var.enable_event_notification) ? tobool("When an existing event notifications CRN is set, enable_event_notification should be true.") : true
 }
 
 module "resource_group" {


### PR DESCRIPTION
### Description

Reduce the validation on the enable_event_notifications in the DA.

Permit an EN CRN to passed and enable_event_notification to be false.
This is to support the stacks use case, where an existing SM and EN are passed, allowing the enable_event_notifications flag to be true or false to control the creation (or not) of additional resources.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

DA only validation updates to better support stacks use case.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
