### PR TITLE
fix: remove endpoint variables

### DIFF
--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -68,8 +68,8 @@ module "kms" {
   create_key_protect_instance = false
   region                      = local.kms_region
   existing_kms_instance_crn   = var.existing_kms_instance_crn
-  key_ring_endpoint_type      = var.kms_endpoint_type
-  key_endpoint_type           = var.kms_endpoint_type
+  key_ring_endpoint_type      = "private"
+  key_endpoint_type           = "private"
   keys = [
     {
       key_ring_name     = local.kms_key_ring_name
@@ -96,7 +96,7 @@ locals {
   secrets_manager_guid                = var.existing_secrets_manager_crn != null ? (length(local.parsed_existing_secrets_manager_crn) > 0 ? local.parsed_existing_secrets_manager_crn[7] : null) : module.secrets_manager.secrets_manager_guid
   secrets_manager_crn                 = var.existing_secrets_manager_crn != null ? var.existing_secrets_manager_crn : module.secrets_manager.secrets_manager_crn
   secrets_manager_region              = var.existing_secrets_manager_crn != null ? (length(local.parsed_existing_secrets_manager_crn) > 0 ? local.parsed_existing_secrets_manager_crn[5] : null) : module.secrets_manager.secrets_manager_region
-  sm_endpoint_type                    = var.existing_secrets_manager_crn != null ? var.existing_secrets_endpoint_type : var.allowed_network == "private-only" ? "private" : "public"
+  sm_endpoint_type                    = "private"
 }
 
 module "secrets_manager" {
@@ -107,7 +107,7 @@ module "secrets_manager" {
   region                   = var.region
   secrets_manager_name     = var.prefix != null ? "${var.prefix}-${var.secrets_manager_instance_name}" : var.secrets_manager_instance_name
   sm_service_plan          = var.service_plan
-  allowed_network          = var.allowed_network
+  allowed_network          = "private-only"
   sm_tags                  = var.secret_manager_tags
   # kms dependency
   kms_encryption_enabled            = true

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -48,16 +48,6 @@ variable "existing_secrets_manager_crn" {
   default     = null
 }
 
-variable "existing_secrets_endpoint_type" {
-  type        = string
-  description = "The endpoint type to use if existing_secrets_manager_crn is specified. Possible values: public, private."
-  default     = "private"
-  validation {
-    condition     = contains(["public", "private"], var.existing_secrets_endpoint_type)
-    error_message = "Only \"public\" and \"private\" are allowed values for 'existing_secrets_endpoint_type'."
-  }
-}
-
 variable "service_plan" {
   type        = string
   description = "The pricing plan to use when provisioning a Secrets Manager instance. Possible values: `standard`, `trial`. Applies only if `provision_sm_instance` is set to `true`."
@@ -65,16 +55,6 @@ variable "service_plan" {
   validation {
     condition     = contains(["standard", "trial"], var.service_plan)
     error_message = "Only \"standard\" and \"trial\" are allowed values for sm_service_plan."
-  }
-}
-
-variable "allowed_network" {
-  type        = string
-  description = "The types of service endpoints to set on the Secrets Manager instance. Possible values: `private-only`, `public-and-private`."
-  default     = "private-only"
-  validation {
-    condition     = contains(["private-only", "public-and-private"], var.allowed_network)
-    error_message = "The specified allowed_network is not a valid selection."
   }
 }
 
@@ -211,16 +191,6 @@ variable "existing_kms_instance_crn" {
   type        = string
   default     = null
   description = "The CRN of the KMS instance (Hyper Protect Crypto Services or Key Protect). Required only if `existing_secrets_manager_crn` or `existing_secrets_manager_kms_key_crn` is not specified. If the KMS instance is in different account you must also provide a value for `ibmcloud_kms_api_key`."
-}
-
-variable "kms_endpoint_type" {
-  type        = string
-  description = "The type of endpoint to use for communicating with the Key Protect or Hyper Protect Crypto Services instance. Possible values: `public`, `private`. Applies only if `existing_secrets_manager_kms_key_crn` is not specified."
-  default     = "private"
-  validation {
-    condition     = can(regex("public|private", var.kms_endpoint_type))
-    error_message = "The kms_endpoint_type value must be 'public' or 'private'."
-  }
 }
 
 variable "kms_key_ring_name" {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -200,7 +200,6 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"existing_secrets_manager_crn":             terraform.Output(t, existingTerraformOptions, "secrets_manager_instance_crn"),
 				"iam_engine_enabled":                       true,
 				"private_engine_enabled":                   true,
-				"existing_secrets_endpoint_type":           "public",
 			},
 		})
 
@@ -229,8 +228,6 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"service_plan":                             "trial",
 				"iam_engine_enabled":                       true,
 				"private_engine_enabled":                   true,
-				"existing_secrets_endpoint_type":           "public",
-				"allowed_network":                          "public-and-private",
 			},
 		})
 


### PR DESCRIPTION
### Description
Remove the endpoint variables from the module calls to Secrets Manager and KMS modules and hard-code the value in the call to be private in order to follow a secure-by-default approach without allowing changes to this.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

Removed `existing_secrets_endpoint_type`, `allowed_network`, and `kms_endpoint_type` to require these values always be pointing to private endpoints/network

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
