### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -7,3 +7,4 @@ CRA_TARGETS:
     CRA_ENVIRONMENT_VARIABLES:  # An optional map of environment variables for CRA, where the key is the variable name and value is the value. Useful for providing TF_VARs.
       TF_VAR_existing_kms_instance_crn: "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9::"
       TF_VAR_resource_group_name: "test"
+      TF_VAR_provider_visibility: "public"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -63,6 +63,23 @@
               "key": "ibmcloud_api_key"
             },
             {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
+            },
+            {
               "key": "use_existing_resource_group"
             },
             {

--- a/solutions/standard/provider.tf
+++ b/solutions/standard/provider.tf
@@ -1,9 +1,11 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
+  visibility       = var.provider_visibility
 }
 provider "ibm" {
   alias            = "kms"
   ibmcloud_api_key = var.ibmcloud_kms_api_key != null ? var.ibmcloud_kms_api_key : var.ibmcloud_api_key
   region           = local.kms_region
+  visibility       = var.provider_visibility
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -8,6 +8,16 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 variable "use_existing_resource_group" {
   type        = bool
   description = "Whether to use an existing resource group."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -201,6 +201,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"iam_engine_enabled":                       true,
 				"private_engine_enabled":                   true,
 				"existing_secrets_endpoint_type":           "public",
+				"provider_visibility":                      "public",
 			},
 		})
 
@@ -230,6 +231,7 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"iam_engine_enabled":                       true,
 				"private_engine_enabled":                   true,
 				"existing_secrets_endpoint_type":           "public",
+				"provider_visibility":                      "public",
 				"allowed_network":                          "public-and-private",
 			},
 		})


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DA , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11333)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

exposes visibility value for the provider in the DA

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
