### PR TITLE
ci: disable `secret_groups` in DA validation to avid name clash

### DIFF
--- a/solutions/fully-configurable/catalogValidationValues.json.template
+++ b/solutions/fully-configurable/catalogValidationValues.json.template
@@ -5,5 +5,6 @@
   "service_plan": "trial",
   "kms_encryption_enabled": true,
   "existing_kms_instance_crn": $HPCS_US_SOUTH_CRN,
-  "region": "eu-de"
+  "region": "eu-de",
+  "secret_groups": "[]"
 }

--- a/solutions/security-enforced/catalogValidationValues.json.template
+++ b/solutions/security-enforced/catalogValidationValues.json.template
@@ -4,5 +4,5 @@
   "prefix": $PREFIX,
   "service_plan": "trial",
   "existing_kms_instance_crn": $HPCS_US_SOUTH_CRN,
-  "region": "eu-de"
+  "secret_groups": "[]"
 }

--- a/solutions/security-enforced/catalogValidationValues.json.template
+++ b/solutions/security-enforced/catalogValidationValues.json.template
@@ -4,5 +4,6 @@
   "prefix": $PREFIX,
   "service_plan": "trial",
   "existing_kms_instance_crn": $HPCS_US_SOUTH_CRN,
+  "region": "eu-de",
   "secret_groups": "[]"
 }


### PR DESCRIPTION
### Description

Validation pipeline failing with:
`Error: [ERROR] Error creating access group: An access group with the name general-secrets-group-access-group already exists. Enter a different name.`

There is no easy way currently to use unique value in catalog pipeline, so disabling group creation for now

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
